### PR TITLE
Add binding.gyp and update package.json for node-gyp.

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,0 +1,12 @@
+{
+  "targets": [
+    {
+      "target_name": "niagrad",
+      "type": "executable",
+      "sources": [ "./tools/niagrad/src/niagrad.c",
+                   "./tools/niagrad/src/str.c" ],
+      "include_dirs": [ "./tools/niagrad/src/" ],
+    }
+  ]
+}
+

--- a/package.json
+++ b/package.json
@@ -9,5 +9,5 @@
   "license": "BSD",
   "repository": { "type": "git", "url": "git@github.com:apkudo/niagra.git" },
   "bugs": { "url": "http://github.com/apkudo/niagra/issues" },
-  "scripts": { "install": "node-waf configure build install distclean" }
+  "scripts": { "preinstall": "node-gyp rebuild" }
 }


### PR DESCRIPTION
wscript is not supported by a newer node now. It would be better to support node-gyp for building niagrad.

Now when running "npm install", it will build niagrad using node-gyp.
